### PR TITLE
Add layout components

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,6 +4,7 @@
     "env"
   ],
   "plugins": [
-    "transform-class-properties"
+    "transform-class-properties",
+    "transform-object-rest-spread"
   ]
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
         "no-use-before-define": 0,
         "no-plusplus": 0,
         "quote-props": 0,
+        "object-curly-newline": 0,
         "react/jsx-filename-extension": 0,
         "jsx-a11y/anchor-is-valid": ["error", {
             components: ["Link"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -878,6 +878,12 @@
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
       "dev": true
     },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+      "dev": true
+    },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
@@ -1172,6 +1178,16 @@
       "dev": true,
       "requires": {
         "babel-plugin-syntax-flow": "6.18.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "6.13.0",
         "babel-runtime": "6.26.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "babel-eslint": "^8.2.2",
     "babel-loader": "^7.1.3",
     "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "clean-webpack-plugin": "^0.1.18",

--- a/src/layouts/MainLayout.js
+++ b/src/layouts/MainLayout.js
@@ -1,0 +1,26 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+function MainLayout({ menu, numberOfGuests, children }) {
+  return (
+    <div id="container">
+      <div className="sidebar">
+        Sidebar goes here:
+        numberOfGuests: {numberOfGuests}
+        menu: {menu.map(dish => <div>{`${dish.title}${dish.price}`}</div>)}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+MainLayout.propTypes = {
+  menu: PropTypes.arrayOf(PropTypes.shape({
+    title: PropTypes.string,
+    price: PropTypes.string,
+  })).isRequired,
+  numberOfGuests: PropTypes.number.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default MainLayout;

--- a/src/pages/AppRoute.js
+++ b/src/pages/AppRoute.js
@@ -1,0 +1,31 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Route } from "react-router-dom";
+
+function AppRoute({ component: Component, layout: Layout, componentProps, ...rest }) {
+  return (
+    <Route
+      {...rest}
+      render={matchProps => (
+        <Layout {...matchProps} {...componentProps}>
+          <Component {...matchProps} {...componentProps} />
+        </Layout>
+      )}
+    />
+  );
+}
+
+AppRoute.defaultProps = {
+  componentProps: {},
+};
+
+AppRoute.propTypes = {
+  /** Which component to render, will get the match props from react-router */
+  component: PropTypes.func.isRequired,
+  /** Which layout component to use, will get the match props from react-router */
+  layout: PropTypes.func.isRequired,
+  /** Custom props to pass to the layout and component */
+  componentProps: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+};
+
+export default AppRoute;


### PR DESCRIPTION
So this PR does three main things:

* Disable object-curly-newline

This allows
```js
function a({ a: A }) {
```
while it previously mandated
```js
function a({
  a: A
}) {
```

* Install transform-object-rest-spread

See https://babeljs.io/docs/plugins/transform-object-rest-spread/

* Add layout components

Now you can use the `AppRoute` component which allows you to provide a layout for the component that will be rendered.