### PR TITLE
Fix index.scss

### DIFF
--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -1,5 +1,4 @@
 @import "shared";
-@import "food-grid";
 @import "recipes";
 @import "loading";
 


### PR DESCRIPTION
This removes the import of `food-grid.scss` which no longer exists.